### PR TITLE
feat: マイページの追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+  def show
+    unless current_user
+      redirect_to anti_habits_path
+      return
+    end
+
+    @user = current_user
+    @anti_habits = current_user.anti_habits.order(created_at: :desc)
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -33,7 +33,7 @@
 
     <!-- ログイン / マイページ -->
     <% if user_signed_in? %>
-      <%= link_to "#user_path(current_user)", class: "flex flex-col items-center py-2 px-4 text-white/90 hover:text-white hover:scale-105 transition-all duration-300 glass-text-shadow" do %>
+      <%= link_to user_path(current_user), class: "flex flex-col items-center py-2 px-4 text-white/90 hover:text-white hover:scale-105 transition-all duration-300 glass-text-shadow" do %>
         <div class="w-6 h-6 mb-1 glass-icon">
           <svg viewBox="0 0 24 24" fill="currentColor" class="w-full h-full">
             <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,42 @@
+<div class="max-w-4xl mx-auto px-4 py-6 pt-20">
+  <!-- マイページのタイトル -->
+  <h1 class="text-3xl font-bold text-white text-shadow mb-6">マイページ</h1>
+
+  <!-- ユーザー情報 -->
+  <div class="glass-card p-6 mb-6">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center">
+        <div class="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mr-4 border border-white/30">
+          <span class="text-xl font-semibold text-white glass-text-shadow"><%= @user.name.first %></span>
+        </div>
+        <div>
+          <h2 class="text-xl font-semibold text-white glass-text-shadow"><%= @user.name %></h2>
+        </div>
+      </div>
+      
+      <!-- ユーザー編集ボタン -->
+      <%= link_to "プロフィール編集", edit_user_registration_path, class: "glass-button px-4 py-2 text-white hover:text-white/90 transition-colors no-underline glass-text-shadow" %>
+    </div>
+  </div>
+
+  <!-- 過去の悪習慣投稿 -->
+  <div class="mb-6">
+    <h2 class="text-xl font-bold text-white text-shadow mb-4">過去の悪習慣投稿</h2>
+    
+    <div class="space-y-4">
+      <% if @anti_habits.any? %>
+        <% @anti_habits.each do |anti_habit| %>
+          <%= render 'anti_habits/anti_habit', anti_habit: anti_habit %>
+        <% end %>
+      <% else %>
+        <!-- 空の状態 -->
+        <div class="glass-card p-12 text-center">
+          <h3 class="text-white text-lg font-bold text-shadow mb-2">
+            まだ悪習慣が投稿されていません
+          </h3>
+          <p class="text-white/90 glass-text-shadow">最初の悪習慣を登録してみましょう</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :anti_habits
+  resources :users, only: %i[ show ]
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/users/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/users/show.html.tailwindcss_spec.rb
+++ b/spec/views/users/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "users/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# issue
close: #12 

# 実装概要
users_controllerを作成し、マイページを作成。
過去の自分の投稿と、ユーザー編集ボタンを配置。

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 自分の投稿一覧が表示されていること
- [ ] ログイン後のフッターからマイページに遷移できること
- [ ] ユーザー編集ボタン押下でユーザー編集ページに遷移できること
- [ ] 他のユーザーのマイページに遷移できないこと

## 補足・備考・後でやること
なし