### PR TITLE
fix: プロフィール編集時にパスワードを求めないように

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [ :create ]
   before_action :configure_account_update_params, only: [ :update ]
 
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   has_many :anti_habits, dependent: :destroy
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }, on: :create
 
   def set_values(omniauth)
     return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,11 +11,6 @@
       </div>
 
       <div class="form-group">
-        <%= f.label :current_password, "現在のパスワード（必須）", class: "block text-sm font-medium text-white mb-2 glass-text-shadow" %>
-        <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full px-4 py-3 rounded-xl bg-white/20 border border-white/30 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-white/50 focus:border-white/50 transition-all backdrop-blur-sm" %>
-      </div>
-
-      <div class="form-group">
         <%= f.submit "更新", class: "w-full px-4 py-3 bg-blue-500/30 border border-blue-300/50 text-white font-semibold rounded-xl hover:bg-blue-500/40 hover:border-blue-300/60 transition-all backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-blue-300/50 glass-text-shadow" %>
       </div>
     <% end %>


### PR DESCRIPTION
# issue
close: #37 

# 実装概要
プロフィール編集時にパスワードを求めないように対応

## 追加実装
なし

## 動作確認チェックリスト
- [ ] プロフィール編集画面でパスワードの入力欄がないこと
- [ ] プロフィール更新(名前のみ)ができること

## 補足・備考・後でやること
なし