### PR TITLE
Feature/#53 logout error fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,16 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found
+    if user_signed_in?
+      redirect_to anti_habits_path, alert: "指定されたページが見つかりません。"
+    else
+      redirect_to root_path, alert: "指定されたページが見つかりません。"
+    end
+  end
 end

--- a/app/views/anti_habits/_anti_habit.html.erb
+++ b/app/views/anti_habits/_anti_habit.html.erb
@@ -40,6 +40,7 @@
     </div>
   <% end %>
 
-  <%= render "shared/reaction_button", anti_habit: anti_habit %>
-
+  <% if user_signed_in? %>
+    <%= render "shared/reaction_button", anti_habit: anti_habit %>
+  <% end %>
 </div>

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -43,7 +43,7 @@
         </div>
       </div>
     <% end %>
-    <% if current_user.own?(@anti_habit) %>
+    <% if current_user&.own?(@anti_habit) %>
       <!-- 記録トグル -->
       <div class="mb-4">
         <div class="flex items-center justify-between p-4 bg-white/10 rounded-lg border border-white/20 backdrop-blur-sm">
@@ -73,7 +73,9 @@
       </div>
     <% end %>
 
-    <%= render "shared/reaction_button", anti_habit: @anti_habit %>
+    <% if user_signed_in? %>
+      <%= render "shared/reaction_button", anti_habit: @anti_habit %>
+    <% end %>
   </div>
 
   <!-- コメントセクション（ログイン時のみ表示） -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= "Anti Habits" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
 
   <body class="bg-glassmorphism">
     <%= render "shared/header" %>
+    <%= render "shared/flash_messages" %>
     <main class="pb-16">
       <%= yield %>
     </main>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,40 @@
+<% flash.each do |type, message| %>
+  <% 
+    css_classes = case type.to_s
+    when 'notice', 'success'
+      'bg-green-50 border-green-200 text-green-800'
+    when 'alert', 'error'
+      'bg-red-50 border-red-200 text-red-800'
+    when 'warning'
+      'bg-yellow-50 border-yellow-200 text-yellow-800'
+    else
+      'bg-blue-50 border-blue-200 text-blue-800'
+    end
+    
+    icon_class = case type.to_s
+    when 'notice', 'success'
+      'fas fa-check-circle text-green-500'
+    when 'alert', 'error'
+      'fas fa-exclamation-circle text-red-500'
+    when 'warning'
+      'fas fa-exclamation-triangle text-yellow-500'
+    else
+      'fas fa-info-circle text-blue-500'
+    end
+  %>
+  
+  <div class="flash-message mx-4 sm:mx-6 lg:mx-8 xl:mx-auto xl:max-w-4xl mb-4 mt-20" data-flash-type="<%= type %>">
+    <div class="<%= css_classes %> border rounded-lg p-3 sm:p-4 shadow-sm">
+      <div class="flex items-start">
+        <div class="flex-shrink-0">
+          <i class="<%= icon_class %> text-base sm:text-lg"></i>
+        </div>
+        <div class="ml-2 sm:ml-3 flex-1 min-w-0">
+          <p class="text-xs sm:text-sm font-medium break-words">
+            <%= message %>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,12 +18,13 @@
       </label>
 
       <!-- ドロップダウンメニュー -->
-      <nav class="absolute top-full right-0 mt-2 w-48 glass-card py-2 
+      <nav class="absolute top-full right-0 mt-2 w-48 bg-gray-700 border border-gray-500 rounded-lg shadow-lg py-2 
                   opacity-0 invisible scale-95 transition-all duration-200 origin-top-right
                   peer-checked:opacity-100 peer-checked:visible peer-checked:scale-100">
-        <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">お問い合わせ</a>
-        <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">利用規約</a>
-        <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">プライバシーポリシー</a>
+        <%# 一時的に非表示 %>
+        <%# <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">お問い合わせ</a> %>
+        <%# <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">利用規約</a> %>
+        <%# <a href="#" class="block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow">プライバシーポリシー</a> %>
         
         <% if user_signed_in? %>
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 text-sm text-white hover:bg-white/20 transition-colors rounded glass-text-shadow' %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -19,6 +19,11 @@
         <%= link_to "ログイン", new_user_session_path, 
             class: "inline-block glass-button bg-white/20 border border-white/30 text-white font-semibold py-3 px-8 rounded-lg transition-all duration-300 hover:bg-white/30 no-underline" %>
       </div>
+      
+      <div class="mt-8 flex justify-center">
+        <%= link_to "悪習慣一覧を見る", anti_habits_path, 
+            class: "inline-block glass-button bg-gray-500/20 border border-gray-300/30 text-white/80 font-medium py-2 px-6 rounded-lg transition-all duration-300 hover:bg-gray-500/30 hover:text-white no-underline" %>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
# issue
close: #53 

# 実装概要
ログアウト時に悪習慣一覧・悪習慣詳細画面に遷移するとエラーが発生していたのを修正

## 追加実装
- トップページに悪習慣一覧を覗けるボタンを設置
- ハンバーガーメニューのデザインを微修正
- フラッシュメッセージ対応
- RecordNotFound時のリダイレクト対応

## 動作確認チェックリスト
- [ ] ログアウト時にもトップページから悪習慣一覧・悪習慣詳細画面へ遷移できること
- [ ] フラッシュメッセージが表示されること
- [ ] URL直接入力で存在しない悪習慣詳細画面へ遷移しようとした時、フラッシュメッセージが表示されてトップページ or 悪習慣一覧ページに遷移されること

## 補足・備考・後でやること
なし