### PR TITLE
feat: 悪習慣記録機能のデザインを修正

### DIFF
--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -45,26 +45,37 @@
     <% end %>
     <% if current_user&.own?(@anti_habit) %>
       <!-- 記録トグル -->
-      <div class="mb-4">
-        <div class="flex items-center justify-between p-4 bg-white/10 rounded-lg border border-white/20 backdrop-blur-sm">
-          <div class="flex items-center">
-            <span class="text-white glass-text-shadow font-medium">今日の記録</span>
-          </div>
-          
-          <div class="flex items-center space-x-3">
-            <% if @today_record %>
-              <span class="text-green-300 text-sm font-medium">記録済み</span>
+      <div class="mb-6">
+        <div class="text-center mb-4">
+          <span class="text-white glass-text-shadow font-medium text-lg">今日の記録：</span>
+        </div>
+        
+        <div class="flex flex-col space-y-3">
+          <% if @today_record %>
+            <!-- 記録済みの状態 - 我慢できた状態を表示 -->
+            <div class="p-4 bg-green-500/20 rounded-xl border-2 border-green-400/30 backdrop-blur-sm">
+              <div class="flex items-center justify-center space-x-2 mb-3">
+                <span class="text-2xl">💪</span>
+                <span class="text-green-200 font-bold text-lg glass-text-shadow">我慢できた</span>
+              </div>
               <%= button_to "記録を削除", anti_habit_record_path(@today_record), 
                     method: :delete, 
                     data: { turbo_confirm: "記録を削除しますか？" },
-                    class: "glass-button px-3 py-1 text-sm text-red-200 hover:text-red-100 transition-colors glass-text-shadow" %>
-            <% else %>
-              <span class="text-gray-300 text-sm font-medium">未記録</span>
-              <%= button_to "記録する", anti_habit_records_path, 
+                    class: "w-full glass-button bg-green-600/30 hover:bg-green-600/40 border border-green-400/40 px-4 py-2 text-green-100 hover:text-white transition-all duration-200 rounded-lg font-medium glass-text-shadow" %>
+            </div>
+          <% else %>
+            <!-- 我慢できたボタン -->
+            <div class="p-4 bg-green-500/10 hover:bg-green-500/20 rounded-xl border-2 border-green-400/20 hover:border-green-400/40 backdrop-blur-sm transition-all duration-200">
+              <%= button_to anti_habit_records_path, 
                     params: { anti_habit_id: @anti_habit.id },
-                    class: "glass-button px-3 py-1 text-sm text-blue-200 hover:text-blue-100 transition-colors glass-text-shadow" %>
-            <% end %>
-          </div>
+                    class: "w-full bg-transparent border-none p-0 text-left" do %>
+                <div class="flex items-center justify-center space-x-2">
+                  <span class="text-2xl">💪</span>
+                  <span class="text-green-200 font-bold text-lg glass-text-shadow">我慢できた</span>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="flex justify-end space-x-4">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -100,7 +100,7 @@
             <div class="text-sm text-white/70 mb-2 glass-text-shadow">今日の記録：</div>
             <div class="space-y-2">
               <button class="w-full p-3 bg-red-500/30 border border-red-300/50 rounded text-red-200 backdrop-blur-sm">やってしまった 😞</button>
-              <button class="w-full p-3 bg-green-500/30 border border-green-300/50 rounded text-green-200 backdrop-blur-sm">できた！ 🎉</button>
+              <button class="w-full p-3 bg-green-500/30 border border-green-300/50 rounded text-green-200 backdrop-blur-sm">我慢できた 💪</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# issue
close: #62 

# 実装概要
- トップページの悪習慣記録機能のデザインを「やってしまった」と「我慢できた」に変更
- 自分の悪習慣詳細ページで悪習慣記録機能を使用する際のデザインを「我慢できた」と「記録を削除」に変更

## 変更前
[![Image from Gyazo](https://i.gyazo.com/8c906b4bb2154af1841ba01289a2ab3b.png)](https://gyazo.com/8c906b4bb2154af1841ba01289a2ab3b)
[![Image from Gyazo](https://i.gyazo.com/db6153a06d8efbeb93c10cbe85962942.png)](https://gyazo.com/db6153a06d8efbeb93c10cbe85962942)
[![Image from Gyazo](https://i.gyazo.com/9a6f6e12ba6b58a3d466dc424020327a.png)](https://gyazo.com/9a6f6e12ba6b58a3d466dc424020327a)

## 変更後
[![Image from Gyazo](https://i.gyazo.com/1653e38fc52b61b37394051d4cb0b2b6.png)](https://gyazo.com/1653e38fc52b61b37394051d4cb0b2b6)
[![Image from Gyazo](https://i.gyazo.com/1614d33cbee03a81512448519059ec54.png)](https://gyazo.com/1614d33cbee03a81512448519059ec54)
[![Image from Gyazo](https://i.gyazo.com/803c299f4cdbfe8940ca60068d5d3683.png)](https://gyazo.com/803c299f4cdbfe8940ca60068d5d3683)

## 追加実装
なし

## 動作確認チェックリスト
- [ ] トップページの悪習慣記録機能のデザインが「やってしまった」と「我慢できた」になっていること
- [ ] 自分の悪習慣詳細ページで悪習慣記録機能を使用する際のデザインが「我慢できた」と「記録を削除」になっていること

## 補足・備考・後でやること
なし