### PR TITLE
fix: メールアドレス重複エラーの際のメッセージを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
   validates :password, presence: true, length: { minimum: 6 }, on: :create
 
+  after_validation :replace_email_taken_error
+
   def set_values(omniauth)
     return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]
     credentials = omniauth["credentials"]
@@ -38,5 +40,16 @@ class User < ApplicationRecord
 
   def reaction?(anti_habit)
     reaction_anti_habits.include?(anti_habit)
+  end
+
+  private
+
+  def replace_email_taken_error
+    if errors.details[:email]&.any? { |d| d[:error] == :taken }
+      # 既存のすべてのエラーをクリア
+      errors.clear
+      # baseエラーとして追加（属性名が前に付かない）
+      errors.add(:base, "登録できませんでした。")
+    end
   end
 end


### PR DESCRIPTION
# issue
close: #67 

# 実装概要
メールアドレス重複エラーの際のメッセージが、登録済みアドレスを特定できるセキュリティ的によくないものだったので修正。
メールアドレス重複エラーがあれば、その他バリデーションエラーを表示せずに「登録できませんでした。」とだけ表示する。

### 既存のエラーメッセージ
[![Image from Gyazo](https://i.gyazo.com/42dba62c0be5babb210f671c30696e54.png)](https://gyazo.com/42dba62c0be5babb210f671c30696e54)

### 修正後のエラーメッセージ
[![Image from Gyazo](https://i.gyazo.com/785fdd5d69e5e1df3b44b48bd9e94319.png)](https://gyazo.com/785fdd5d69e5e1df3b44b48bd9e94319)

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 会員登録時に登録済みのemailで登録しようとすると「修正後のエラーメッセージ」が表示されること

## 補足・備考・後でやること
なし