### PR TITLE
feat: モバイルブラウザで閲覧した場合のテーマカラーを赤からnordの色味に修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title><%= "Anti Habits" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#edeff4">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
# issue
close: #40 

# 実装概要
モバイルブラウザで表示された時に、デフォルトテーマカラーが赤なので、違和感がないようにdaisyUIのテーマ"nord"にあったものに修正

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 下記のようにデザインが修正されていること

### モバイルブラウザでのテーマカラー
| 修正前 | 修正後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/d7f9d8c020f8cee1e29dcc84795363a9.png)](https://gyazo.com/d7f9d8c020f8cee1e29dcc84795363a9) | [![Image from Gyazo](https://i.gyazo.com/eb197a8b222f8bbde8c2900d16d525da.png)](https://gyazo.com/eb197a8b222f8bbde8c2900d16d525da) |

## 補足・備考・後でやること
なし