### PR TITLE
feat: ヘッダーアイコンをリンクに

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,9 @@
 <div class="navbar bg-base-100">
   <div class="navbar-start">
     <div class="btn btn-ghost text-xl cursor-default">
-      <span class="inline ml-2">Anti Habits</span>
+      <%= link_to (user_signed_in? ? anti_habits_path : root_path) do %>
+        <span class="inline ml-2">Anti Habits</span>
+      <% end %>
     </div>
   </div>
   


### PR DESCRIPTION
# issue
close: #72 

# 実装概要
ヘッダーのアイコンをリンクに修正。
ログイン時は悪習慣一覧へのリンクに。
ログアウト時はトップページへのリンクに。

## 追加実装
なし

## 動作確認チェックリスト
- [ ] ログイン時にヘッダーアイコンクリックで悪習慣一覧へ遷移すること
- [ ] ログアウト時にヘッダーアイコンクリックでトップページへ遷移すること

## 補足・備考・後でやること
なし