### PR TITLE
Feature/#71 comments count

### DIFF
--- a/app/views/anti_habits/_anti_habit.html.erb
+++ b/app/views/anti_habits/_anti_habit.html.erb
@@ -51,8 +51,12 @@
 
     <!-- リアクションボタン -->
     <% if user_signed_in? %>
-      <div class="mt-4">
+      <div class="flex items-center mt-4 space-x-4">
         <%= render "shared/reaction_button", anti_habit: anti_habit %>
+        <div class="flex items-center space-x-1">
+          <i class="fas fa-comment"></i>
+          <%= anti_habit.comments.count %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -98,8 +98,12 @@
 
       <!-- リアクションボタン -->
       <% if user_signed_in? %>
-        <div class="mt-4">
+        <div class="flex items-center mt-4 space-x-4">
           <%= render "shared/reaction_button", anti_habit: @anti_habit %>
+          <div class="flex items-center space-x-1">
+            <i class="fas fa-comment"></i>
+            <%= @anti_habit.comments.count %>
+          </div>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
# issue
close: #71 

# 実装概要
悪習慣一覧のカードにコメント数の表示を追加
悪習慣詳細画面にコメント数の表示を追加

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 下記のようにコメント数の表示が追加されていること

### 一覧画面のカード
| 修正前 | 修正後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/c8b53a5a06f266aca07322e59a897209.png)](https://gyazo.com/c8b53a5a06f266aca07322e59a897209) | [![Image from Gyazo](https://i.gyazo.com/7cab0a96663dd992755f147e54815f4f.png)](https://gyazo.com/7cab0a96663dd992755f147e54815f4f) |

### 詳細画面
修正前
[![Image from Gyazo](https://i.gyazo.com/e9a1aa15671ba0d928ecd323cb26ccba.png)](https://gyazo.com/e9a1aa15671ba0d928ecd323cb26ccba)
修正後
 [![Image from Gyazo](https://i.gyazo.com/3bf9ccb16c36ad40f8ae61db5d87fd68.png)](https://gyazo.com/3bf9ccb16c36ad40f8ae61db5d87fd68)

## 補足・備考・後でやること
なし