### PR TITLE
Feature/#73 tag to link

### DIFF
--- a/app/controllers/anti_habits_controller.rb
+++ b/app/controllers/anti_habits_controller.rb
@@ -2,7 +2,19 @@ class AntiHabitsController < ApplicationController
   before_action :authenticate_user!, except: [ :index, :show ]
 
   def index
-    @anti_habits = AntiHabit.all.includes(:user, :tags).order(created_at: :desc)
+    @tag_name = params[:tag].presence
+
+    @anti_habits =
+      if @tag_name
+        AntiHabit
+          .includes(:user, :tags)
+          .tagged_with(@tag_name)
+          .order(created_at: :desc)
+      else
+        AntiHabit
+          .includes(:user, :tags)
+          .order(created_at: :desc)
+      end
   end
 
   def new

--- a/app/models/anti_habit.rb
+++ b/app/models/anti_habit.rb
@@ -10,6 +10,10 @@ class AntiHabit < ApplicationRecord
   validates :description, length: { maximum: 80 }
   validate :validate_tag_names
 
+  scope :tagged_with, ->(name) {
+    joins(:tags).where(tags: { name: name })
+  }
+
   attr_accessor :tag_names
 
   after_save :save_tags_without_validation

--- a/app/views/anti_habits/_anti_habit.html.erb
+++ b/app/views/anti_habits/_anti_habit.html.erb
@@ -37,7 +37,9 @@
         <div class="flex flex-wrap gap-2">
           <% anti_habit.tags.limit(3).each do |tag| %>
             <div class="badge badge-outline badge-primary">
-              #<%= tag.name %>
+              <%= link_to anti_habits_path(tag: tag.name) do %>
+                #<%= tag.name %>
+              <% end %>
             </div>
           <% end %>
           <% if anti_habit.tags.count > 3 %>

--- a/app/views/anti_habits/index.html.erb
+++ b/app/views/anti_habits/index.html.erb
@@ -1,8 +1,17 @@
 <div class="container mx-auto px-4 py-6">
   <div class="mb-8">
-    <h1 class="text-4xl font-bold text-center mb-4">悪習慣一覧</h1>
+    <h1 class="text-4xl font-bold text-center mb-4">
+      悪習慣一覧<br class="sm:hidden"><%= @tag_name.presence ? " (#{@tag_name})" : "" %>
+    </h1>
+    <% if @tag_name.presence %>
+      <div class="mt-2 mb-2 text-center">
+        <%= link_to "タグフィルタを解除", anti_habits_path, class: "btn btn-sm" %>
+      </div>
+    <% end %>
     <p class="text-center text-base-content/70">みんなが克服したい悪習慣を見てみましょう</p>
   </div>
+
+
 
   <!-- 悪習慣一覧 -->
   <div class="space-y-6">

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -42,7 +42,9 @@
           <div class="flex flex-wrap gap-2">
             <% @anti_habit.tags.each do |tag| %>
               <div class="badge badge-outline badge-primary">
-                #<%= tag.name %>
+                <%= link_to anti_habits_path(tag: tag.name) do %>
+                  #<%= tag.name %>
+                <% end %>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
# issue
close: #73 

# 実装概要
タグによる悪習慣の絞り込み機能を追加しました。
タグをクリックすると、そのタグに紐づく悪習慣のみを一覧表示できるようにしました。
現在絞り込み中のタグ名とフィルタ解除リンクも追加しました。

## 追加実装
なし

## 動作確認チェックリスト
- [ ] タグをクリックすると、そのタグに紐づく悪習慣だけが表示されること
- [ ] 一覧ページで絞り込み中のタグ名が表示されること
- [ ] フィルタ解除リンクで全件表示に戻れること

## 補足・備考・後でやること
なし