### PR TITLE
Feature/#75 dynamic ogp

### DIFF
--- a/app/controllers/anti_habits_controller.rb
+++ b/app/controllers/anti_habits_controller.rb
@@ -34,6 +34,10 @@ class AntiHabitsController < ApplicationController
     @anti_habit = AntiHabit.includes(:tags).find(params[:id])
     @today_record = @anti_habit.today_record if current_user&.own?(@anti_habit)
     @comments = @anti_habit.comments.includes(:user).order(created_at: :desc)
+
+    # タグの設定
+    @url = "https://res.cloudinary.com/antihabits/image/upload/l_text:Sawarabi%20Gothic_50_solid:#{@anti_habit.title},co_rgb:333,w_500,c_fit/v1757602327/anti_habits_dynamic_ogp_zyyjyk.png"
+    set_meta_tags(og: { image: @url }, twitter: { image: @url })
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def default_meta_tags
+  def default_meta_tags(url: "https://res.cloudinary.com/antihabits/image/upload/v1757773129/anti_habits_static_ogp_zg7q8j.png")
     {
       site: "Anti Habits",
       title: "Anti Habits",
@@ -13,12 +13,12 @@ module ApplicationHelper
         description: :description,
         type: "website",
         url: request.original_url,
-        image: image_url("Anti_Habits.png"),
+        image: url,
         locale: "ja-JP"
       },
         twitter: {
         card: "summary_large_image",
-        image: image_url("Anti_Habits.png")
+        image: url
       }
     }
   end

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -91,6 +91,11 @@
 
         <!-- 編集・削除ボタン -->
         <div class="card-actions justify-end">
+          <%= link_to "Xでシェアする",
+                      "https://twitter.com/intent/tweet?url=#{root_url}anti_habit/#{@anti_habit.id}&text=#{CGI.escape("Anti Habitsで悪習慣を登録！")}%0A#{CGI.escape("悪習慣を辞められるか監視してください！")}\n&hashtags=#{CGI.escape("AntiHabits")}",
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      class: "btn btn-outline btn-neutral" %>
           <%= link_to "編集", edit_anti_habit_path(@anti_habit), class: "btn btn-outline btn-primary" %>
           <%= link_to "削除", anti_habit_path(@anti_habit), 
                 data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, 


### PR DESCRIPTION
# issue
close: #75 

# 実装概要
悪習慣詳細ページのみ動的OGPに対応しました。
また、自分の悪習慣詳細ページのみ、Xシェアのボタンを追加しました。

## 追加実装
デフォルトOGP画像も差し替えました

## 動作確認チェックリスト
- [ ] デフォルトOGP画像が新しいものになっていること(後述)
- [ ] 自分の投稿した悪習慣の詳細画面にXシェアボタンが表示されていること
- [ ] Xシェア時のOGP画像が動的に変更されること

### Xシェアボタン
| 修正前 | 修正後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/5d6e8b208566dde0bf01c401c2e29150.png)](https://gyazo.com/5d6e8b208566dde0bf01c401c2e29150) | [![Image from Gyazo](https://i.gyazo.com/9a94b2a4d671935ee7d78b6846accdd5.png)](https://gyazo.com/9a94b2a4d671935ee7d78b6846accdd5) |

### デフォルトOGP画像
![](https://res.cloudinary.com/antihabits/image/upload/v1757773129/anti_habits_static_ogp_zg7q8j.png)

### 動的OGP画像(サンプル)
![](https://res.cloudinary.com/antihabits/image/upload/l_text:Sawarabi%20Gothic_50_solid:%E6%82%AA%E7%BF%92%E6%85%A3%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB,co_rgb:333,w_500,c_fit/v1757602327/anti_habits_dynamic_ogp_zyyjyk.png)

## 補足・備考・後でやること
Xシェアボタンにアイコンを設定する。