### PR TITLE
Fix/#112 x share

### DIFF
--- a/app/controllers/anti_habits_controller.rb
+++ b/app/controllers/anti_habits_controller.rb
@@ -35,8 +35,18 @@ class AntiHabitsController < ApplicationController
     @today_record = @anti_habit.today_record if current_user&.own?(@anti_habit)
     @comments = @anti_habit.comments.includes(:user).order(created_at: :desc)
 
+    # font sizeの計算
+    font_size = if @anti_habit.title.length > 15
+                  "25"
+    elsif @anti_habit.title.length > 10
+                  "30"
+    else
+                  "50"
+    end
+
+
     # タグの設定
-    @url = "https://res.cloudinary.com/antihabits/image/upload/l_text:Sawarabi%20Gothic_50_solid:#{@anti_habit.title},co_rgb:333,w_500,c_fit/v1757602327/anti_habits_dynamic_ogp_zyyjyk.png"
+    @url = "https://res.cloudinary.com/antihabits/image/upload/l_text:Sawarabi%20Gothic_#{font_size}_solid:#{@anti_habit.title},co_rgb:333,w_500,c_fit/v1757602327/anti_habits_dynamic_ogp_zyyjyk.png"
     set_meta_tags(og: { image: @url }, twitter: { image: @url })
   end
 

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -92,7 +92,7 @@
         <!-- 編集・削除ボタン -->
         <div class="card-actions justify-end">
           <%= link_to "Xでシェアする",
-                      "https://twitter.com/intent/tweet?url=#{root_url}anti_habit/#{@anti_habit.id}&text=#{CGI.escape("Anti Habitsで悪習慣を登録！")}%0A#{CGI.escape("悪習慣を辞められるか監視してください！")}\n&hashtags=#{CGI.escape("AntiHabits")}",
+                      "https://twitter.com/intent/tweet?url=#{root_url}anti_habits/#{@anti_habit.id}&text=#{CGI.escape("Anti Habitsで悪習慣を登録！")}%0A#{CGI.escape("悪習慣を辞められるか監視してください！")}\n&hashtags=#{CGI.escape("AntiHabits")}",
                       target: "_blank",
                       rel: "noopener noreferrer",
                       class: "btn btn-outline btn-neutral" %>


### PR DESCRIPTION
# issue
close: #112 

# 実装概要
Xシェア時のURLを修正

## 追加実装
動的OGPのタイトル文字サイズを動的に変更されるように修正

## 動作確認チェックリスト
- [ ] Xシェア時のURLが`https://anti-habits.onrender.com/anti_habits/:id`となっていること
- [ ] 動的OGP画像のフォントサイズが下記の条件で動的に変更されること
   - タイトルの文字数が16文字以上なら25ピクセルに
   - タイトルの文字数が11文字以上なら30ピクセルに
   - タイトルの文字数が10文字以下なら50ピクセルに

## 補足・備考・後でやること
なし