### PR TITLE
feat: LINE友だち追加ボタンを設置

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,6 +26,9 @@
             method: :post,
             class: "btn btn-success btn-sm w-full",
             data: { turbo: false } %>
+          <a href="https://lin.ee/sWL8Gc5" class="btn btn-success btn-sm w-full">
+            友だち追加
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# issue
close: #122 

# 実装概要
マイページに友だち追加ボタンを設置

## 修正イメージ
修正前
[![Image from Gyazo](https://i.gyazo.com/105f954b2ef0fa551c6599c9d5302539.png)](https://gyazo.com/105f954b2ef0fa551c6599c9d5302539)

修正後
[![Image from Gyazo](https://i.gyazo.com/f5c9a552d21c23813c2cb165cfe663ed.png)](https://gyazo.com/f5c9a552d21c23813c2cb165cfe663ed)

## 追加実装
なし

## 動作確認チェックリスト
- [ ] マイページに友だち追加ボタンが表示されていること

## 補足・備考・後でやること
LINEアイコン周り