### PR TITLE
feat: コメント投稿機能の非同期対応

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,14 +5,7 @@ class CommentsController < ApplicationController
   def create
     @comment = @anti_habit.comments.build(comment_params)
     @comment.user = current_user
-    if @comment.save
-      redirect_to anti_habit_path(@anti_habit), notice: "応援メッセージを投稿しました"
-    else
-      # エラー時はshowページを再表示（エラーメッセージ付き）
-      @today_record = @anti_habit.today_record if current_user&.own?(@anti_habit)
-      @comments = @anti_habit.comments.includes(:user).order(created_at: :desc)
-      render "anti_habits/show", status: :unprocessable_entity
-    end
+    @comment.save
   end
 
   private

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -109,7 +109,7 @@
           <%= render "shared/reaction_button", anti_habit: @anti_habit %>
           <div class="flex items-center space-x-1">
             <i class="fas fa-comment"></i>
-            <%= @anti_habit.comments_count %>
+            <span id="comments-count"><%= @anti_habit.comments_count %></span>件
           </div>
         </div>
       <% end %>
@@ -123,33 +123,35 @@
         <h2 class="card-title text-2xl mb-6">
           応援メッセージ
           <div class="badge badge-neutral">
-            <%= @anti_habit.comments_count %>件
+            <span id="comments-count2"><%= @anti_habit.comments_count %></span>件
           </div>
         </h2>
 
         <!-- 新規コメントフォーム -->
         <div class="mb-6">
-          <%= render "comments/form" %>
+          <%= render "comments/form", comment: Comment.new, anti_habit: @anti_habit %>
         </div>
 
         <!-- 既存コメント一覧 -->
         <div class="space-y-4">
-          <% if @comments.any? %>
-            <%= render @comments %>
-          <% else %>
-            <div class="hero min-h-32">
-              <div class="hero-content text-center">
-                <div>
-                  <p class="text-base-content/60 mb-2">
-                    まだ応援メッセージはありません
-                  </p>
-                  <p class="text-base-content/60 text-sm">
-                    最初の応援メッセージを投稿してみませんか？
-                  </p>
+          <div id="comments-list">
+            <% if @comments.any? %>
+              <%= render @comments %>
+            <% else %>
+              <div class="hero min-h-32">
+                <div class="hero-content text-center">
+                  <div>
+                    <p class="text-base-content/60 mb-2">
+                      まだ応援メッセージはありません
+                    </p>
+                    <p class="text-base-content/60 text-sm">
+                      最初の応援メッセージを投稿してみませんか？
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,36 +1,38 @@
-<%= form_with model: [@anti_habit, @comment || Comment.new], local: true, class: "space-y-4" do |form| %>
-  <!-- エラーメッセージ -->
-  <% if @comment&.errors&.any? %>
-    <div class="alert alert-error flex items-center">
-      <i class="fas fa-exclamation-circle shrink-0 text-lg mr-3"></i>
-      <div>
-        <h3 class="font-bold">入力内容を確認してください</h3>
+<div id="comment-form">
+  <%= form_with model: [anti_habit, comment || Comment.new], local: false, class: "space-y-4" do |form| %>
+    <!-- エラーメッセージ -->
+    <% if comment&.errors&.any? %>
+      <div class="alert alert-error flex items-center">
+        <i class="fas fa-exclamation-circle shrink-0 text-lg mr-3"></i>
         <div>
-          <% @comment.errors.full_messages.each do |message| %>
-            <div><%= message %></div>
-          <% end %>
+          <h3 class="font-bold">入力内容を確認してください</h3>
+          <div>
+            <% comment.errors.full_messages.each do |message| %>
+              <div><%= message %></div>
+            <% end %>
+          </div>
         </div>
       </div>
+    <% end %>
+
+    <!-- コメント入力 -->
+    <div class="form-control">
+      <div class="label">
+        <span class="label-text">応援メッセージ</span>
+      </div>
+      <%= form.text_area :body, 
+          rows: 4,
+          class: "textarea textarea-bordered w-full",
+          placeholder: "頑張っていますね！応援しています！",
+          maxlength: 500 %>
+      <div class="label">
+        <span class="label-text-alt">最大500文字</span>
+      </div>
+    </div>
+
+    <!-- 送信ボタン -->
+    <div class="form-control">
+      <%= form.submit "応援メッセージを送る", class: "btn btn-success" %>
     </div>
   <% end %>
-
-  <!-- コメント入力 -->
-  <div class="form-control">
-    <div class="label">
-      <span class="label-text">応援メッセージ</span>
-    </div>
-    <%= form.text_area :body, 
-        rows: 4,
-        class: "textarea textarea-bordered w-full",
-        placeholder: "頑張っていますね！応援しています！",
-        maxlength: 500 %>
-    <div class="label">
-      <span class="label-text-alt">最大500文字</span>
-    </div>
-  </div>
-
-  <!-- 送信ボタン -->
-  <div class="form-control">
-    <%= form.submit "応援メッセージを送る", class: "btn btn-success" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,23 @@
+<% if @comment.errors.present? %>
+  <%# エラーメッセージを表示 %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: @comment, anti_habit: @comment.anti_habit %>
+  <% end %>
+<% else %>
+  <%# リストの一番上に追加 %>
+  <%= turbo_stream.prepend "comments-list" do %>
+    <%= render 'comments/comment', comment: @comment %>
+  <% end %>
+  <%# formを空で更新 %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: Comment.new, anti_habit: @comment.anti_habit %>
+  <% end %>
+  <%# コメント数を更新 %>
+  <%= turbo_stream.update "comments-count" do %>
+    <%= @comment.anti_habit.comments_count %>
+  <% end %>
+  <%# コメント数を更新 %>
+  <%= turbo_stream.update "comments-count2" do %>
+    <%= @comment.anti_habit.comments_count %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
# issue
close: #80 

# 実装概要
コメント投稿機能の非同期対応

## 追加実装
なし

## 動作確認チェックリスト
- [ ] コメント登録時に更新がかからないこと
- [ ] コメント登録した場合、コメント一覧の最上部にコメントが追加されること
- [ ] コメント登録した場合、コメント入力フォームが空で更新されること
- [ ] コメント登録した場合、コメント数も更新されること

## 補足・備考・後でやること
なし