### PR TITLE
feat: 独自ドメインに対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,10 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+
+    config.hosts << "www.anti-habits.com"
+  config.hosts << "anti-habits.com"
+  config.hosts << "anti-habits.onrender.com"
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -82,7 +86,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: "anti-habits.onrender.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "anti-habits.com", protocol: "https" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.default_options = { from: ENV["GMAIL_USERNAME"] }
   config.action_mailer.smtp_settings = {

--- a/lib/tasks/line_pushnotification.rake
+++ b/lib/tasks/line_pushnotification.rake
@@ -6,7 +6,7 @@ namespace :line_pushnotification do
     )
 
     message = Line::Bot::V2::MessagingApi::TextMessage.new( # No need to pass `type: "text"`
-      text: "今日の悪習慣進捗を登録しましょう \n https://anti-habits.onrender.com/"
+      text: "今日の悪習慣進捗を登録しましょう \n https://anti-habits.com/"
     )
 
     User.all.each do |user|


### PR DESCRIPTION
# issue
close: #94 

# 実装概要
独自ドメインに対応

www.anti-habits.com
anti-habits.com
anti-habits.onrender.com（Renderドメインも維持）

# 動作確認項目
- [ ] `https://www.anti-habits.com/` へアクセスできること
- [ ] `https://anti-habits.com/` へアクセスできること
- [ ] リダイレクトが正常に動作すること

## 補足・備考・後でやること
なし