### PR TITLE
feat: プライバシーポリシーの追加と利用規約の一部修正

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,7 @@ class StaticPagesController < ApplicationController
 
   def terms
   end
+
+  def privacy
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,12 +18,14 @@
         <% if user_signed_in? %>
           <li><%= link_to 'アプリについて', root_path %></li>
           <li><%= link_to '利用規約', terms_path %></li>
+          <li><%= link_to 'プライバシーポリシー', privacy_path %></li>
           <li><%= link_to "お問い合わせ", "https://forms.gle/x7umjBWhLLq82aaF6", target: "_blank", rel: "noopener noreferrer" %></li>
           <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>
         <% else %>
           <li><%= link_to 'ログイン', new_user_session_path %></li>
           <li><%= link_to '新規登録', new_user_registration_path %></li>
           <li><%= link_to '利用規約', terms_path %></li>
+          <li><%= link_to 'プライバシーポリシー', privacy_path %></li>
           <li><%= link_to "お問い合わせ", "https://forms.gle/x7umjBWhLLq82aaF6", target: "_blank", rel: "noopener noreferrer" %></li>
         <% end %>
       </ul>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,136 @@
+
+<div class="container mx-auto px-4 py-8 max-w-4xl">
+  <!-- ヘッダー -->
+  <div class="text-center mb-12">
+    <h1 class="text-4xl font-bold mb-4">プライバシーポリシー</h1>
+  </div>
+
+  <!-- プライバシーポリシー内容 -->
+  <div class="card bg-base-100 shadow-lg">
+    <div class="card-body prose prose-lg max-w-none">
+      
+      <!-- 前文 -->
+      <div class="mb-8">
+        <p class="text-base-content/80 leading-relaxed">
+          本プライバシーポリシーは、当社サービスの利用に際してお客様の個人情報がどのように取得・利用されるかについて定めたものです。
+        </p>
+      </div>
+
+      <!-- 目次 -->
+      <div class="bg-base-200 p-6 rounded-lg mb-8">
+        <h3 class="text-lg font-semibold mb-4">目次</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+          <a href="#collection" class="link">1. お客様から取得する情報</a>
+          <a href="#purpose" class="link">2. お客様の情報を利用する目的</a>
+          <a href="#safety" class="link">3. 安全管理のために講じた措置</a>
+          <a href="#third-party" class="link">4. 第三者提供</a>
+          <a href="#analytics" class="link">5. アクセス解析ツール</a>
+          <a href="#changes" class="link">6. プライバシーポリシーの変更</a>
+          <a href="#contact" class="link">7. お問い合わせ</a>
+          <a href="#business-info" class="link">8. 事業者情報</a>
+        </div>
+      </div>
+
+      <!-- 各条項 -->
+      <section id="collection" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">1. お客様から取得する情報</h2>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          当社は、お客様から以下の情報を取得します。
+        </p>
+        <ul class="list-disc list-inside space-y-2 text-base-content/80">
+          <li>氏名（ニックネームやペンネームも含む）</li>
+          <li>メールアドレス</li>
+          <li>写真や動画</li>
+          <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+          <li>Cookie（クッキー）を用いて生成された識別情報</li>
+        </ul>
+      </section>
+
+      <section id="purpose" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">2. お客様の情報を利用する目的</h2>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          当社は、お客様から取得した情報を、以下の目的のために利用します。
+        </p>
+        <ul class="list-disc list-inside space-y-2 text-base-content/80">
+          <li>当社サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+          <li>お客様の当社サービスの利用履歴を管理するため</li>
+          <li>当社サービスにおけるお客様の行動履歴を分析し、当社サービスの維持改善に役立てるため</li>
+          <li>当社のサービスに関するご案内をするため</li>
+          <li>当社の規約や法令に違反する行為に対応するため</li>
+          <li>以上の他、当社サービスの提供、維持、保護及び改善のため</li>
+        </ul>
+      </section>
+
+      <section id="safety" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">3. 安全管理のために講じた措置</h2>
+        <p class="text-base-content/80 leading-relaxed">
+          当社が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。
+        </p>
+      </section>
+
+      <section id="third-party" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">4. 第三者提供</h2>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          当社は、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。
+        </p>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          但し、次の場合は除きます。
+        </p>
+        <ul class="list-disc list-inside space-y-2 text-base-content/80">
+          <li>個人データの取扱いを外部に委託する場合</li>
+          <li>当社や当社サービスが買収された場合</li>
+          <li>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）</li>
+          <li>その他、法律によって合法的に第三者提供が許されている場合</li>
+        </ul>
+      </section>
+
+      <section id="analytics" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">5. アクセス解析ツール</h2>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          当社は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。
+        </p>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。
+        </p>
+        <div class="bg-info/10 border-l-4 border-info p-4">
+          <h4 class="font-semibold text-info mb-2">Googleアナリティクスについて</h4>
+          <p class="text-sm text-base-content/80">
+            詳しくは以下のリンクからご確認ください：<br>
+            <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" target="_blank" class="link text-primary">
+              https://marketingplatform.google.com/about/analytics/terms/jp/
+            </a>
+          </p>
+        </div>
+      </section>
+
+      <section id="changes" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">6. プライバシーポリシーの変更</h2>
+        <p class="text-base-content/80 leading-relaxed">
+          当社は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。
+        </p>
+      </section>
+
+      <section id="contact" class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-primary">7. お問い合わせ</h2>
+        <p class="text-base-content/80 leading-relaxed mb-4">
+          お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、問い合わせフォームよりご連絡ください。
+        </p>
+        <div class="bg-warning/10 border-l-4 border-warning p-4">
+          <h4 class="font-semibold text-warning mb-2">ご注意事項</h4>
+          <div class="text-sm text-base-content/80 space-y-2">
+            <p>この場合、必ず、運転免許証のご提示等当社が指定する方法により、ご本人からのご請求であることの確認をさせていただきます。</p>
+            <p>なお、情報の開示請求については、開示の有無に関わらず、ご申請時に一件あたり1,000円の事務手数料を申し受けます。</p>
+          </div>
+        </div>
+      </section>
+      
+      <!-- 制定日 -->
+      <div class="text-right mt-12 pt-8 border-t border-base-300">
+        <p class="text-base-content/60 text-sm">
+          2025年11月06日 制定
+        </p>
+      </div>
+      
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -3,9 +3,6 @@
   <!-- ヘッダー -->
   <div class="text-center mb-12">
     <h1 class="text-4xl font-bold mb-4">利用規約</h1>
-    <div class="text-sm text-base-content/70">
-      最終更新日：2025年11月06日
-    </div>
   </div>
 
   <!-- 利用規約内容 -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   root "static_pages#top"
   get "terms" => "static_pages#terms"
+  get "privacy" => "static_pages#privacy"
 
   resources :anti_habits do
     resources :comments, only: %i[ create ]


### PR DESCRIPTION
# issue
close: #95 

# 実装概要
プライバシーポリシーの追加
「KIYAC」を用いてプライバシーポリシーを作成し、ハンバーガーメニューから遷移できるように。

| 修正前 | 修正後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/e8227c80bc2e241143af956e06c12511.png)](https://gyazo.com/e8227c80bc2e241143af956e06c12511) | [![Image from Gyazo](https://i.gyazo.com/2e4b035adfcde71c42f927262316ec94.png)](https://gyazo.com/2e4b035adfcde71c42f927262316ec94) |

## 追加実装
なし

## 動作確認チェックリスト
- [ ] ハンバーガーメニューからプライバシーポリシーに遷移できること

## 補足・備考・後でやること
なし
