### PR TITLE
fix: LINE通知設定の項目で未実装のものを非表示に

### DIFF
--- a/app/views/notification_settings/_form.html.erb
+++ b/app/views/notification_settings/_form.html.erb
@@ -35,7 +35,7 @@
 </div>
 
 <!-- 反応で通知（チェックボックス） -->
-<div class="form-control">
+<div class="form-control hidden">
     <label class="label cursor-pointer">
         <%= form.check_box :notify_on_reaction, class: "checkbox" %>
         <span class="label-text ml-2">いいねやリアクションで通知(未実装)</span>
@@ -43,7 +43,7 @@
 </div>
 
 <!-- コメントで通知（チェックボックス） -->
-<div class="form-control">
+<div class="form-control hidden">
     <label class="label cursor-pointer">
         <%= form.check_box :notify_on_comment, class: "checkbox" %>
         <span class="label-text ml-2">コメントで通知(未実装)</span>


### PR DESCRIPTION
# issue
close: #180 

# 実装概要
LINE通知設定の項目で未実装のものを非表示に

| 修正前 | 修正後 |
| --- | --- |
| <img width="1744" height="584" alt="CleanShot 2026-01-13 at 08 59 43@2x" src="https://github.com/user-attachments/assets/9edadc8a-603b-446f-b156-b50d987d93ee" /> | <img width="1726" height="394" alt="CleanShot 2026-01-13 at 08 58 54@2x" src="https://github.com/user-attachments/assets/b1c77b52-b586-4bbd-9eb0-d84ac24258cc" /> |


## 追加実装
なし

## 動作確認チェックリスト
- [ ] LINE通知設定の項目で未実装のものが非表示になっていること

## 補足・備考・後でやること
未実装の項目を実装して再度表示させる