### PR TITLE
feat: ブックマークボタンの位置を変更

### DIFF
--- a/app/views/anti_habits/_anti_habit.html.erb
+++ b/app/views/anti_habits/_anti_habit.html.erb
@@ -1,5 +1,12 @@
 <div class="card bg-base-100 shadow-xl mb-4 hover:shadow-2xl transition-shadow rounded-2xl border border-base-300">
-  <div class="card-body">
+  <div class="card-body relative">
+    <!-- ブックマークボタン（右上） -->
+    <% if user_signed_in? && current_user.can_bookmark?(anti_habit) %>
+      <div class="absolute top-4 right-4">
+        <%= render "shared/bookmark_button", anti_habit: anti_habit %>
+      </div>
+    <% end %>
+
     <!-- ヘッダー部分：ユーザー名と作成日 -->
     <div class="flex items-center justify-between mb-4">
       <div class="flex items-center">
@@ -73,9 +80,6 @@
           <i class="fas fa-comment"></i>
           <%= anti_habit.comments_count %>
         </div>
-        <% if current_user.can_bookmark?(anti_habit) %>
-          <%= render "shared/bookmark_button", anti_habit: anti_habit %>
-        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/anti_habits/show.html.erb
+++ b/app/views/anti_habits/show.html.erb
@@ -1,7 +1,14 @@
 <div class="container mx-auto px-4 py-6">
   <!-- メイン投稿 -->
   <div class="card bg-base-100 shadow-xl rounded-2xl border border-base-300 mb-8">
-    <div class="card-body p-8">
+    <div class="card-body p-8 relative">
+      <!-- ブックマークボタン（右上） -->
+      <% if user_signed_in? && current_user&.can_bookmark?(@anti_habit) %>
+        <div class="absolute top-4 right-4">
+          <%= render "shared/bookmark_button", anti_habit: @anti_habit %>
+        </div>
+      <% end %>
+
       <!-- ユーザー情報 -->
       <div class="flex items-center justify-between mb-6">
         <div class="flex items-center">
@@ -223,9 +230,6 @@
             <i class="fas fa-comment"></i>
             <span id="comments-count"><%= @anti_habit.comments_count %></span>件
           </div>
-          <% if current_user.can_bookmark?(@anti_habit) %>
-            <%= render "shared/bookmark_button", anti_habit: @anti_habit %>
-          <% end %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
# issue
close: #200 

# 実装概要
ブックマークボタンの位置を右上に変更

| 修正前 | 修正後 |
| --- | --- |
| <img width="3840" height="1936" alt="CleanShot 2026-02-11 at 23 26 23@2x" src="https://github.com/user-attachments/assets/4bfef9f0-1fee-474d-a84a-4e04c0fada6f" /> | <img width="3840" height="1936" alt="CleanShot 2026-02-11 at 23 24 16@2x" src="https://github.com/user-attachments/assets/4c46e078-c0d9-40f6-9a90-e9e319728385" /> |
| <img width="3840" height="1936" alt="CleanShot 2026-02-11 at 23 26 08@2x" src="https://github.com/user-attachments/assets/b5423a1a-dbd3-4a72-93bc-03c157996bf2" /> | <img width="3840" height="1936" alt="CleanShot 2026-02-11 at 23 24 42@2x" src="https://github.com/user-attachments/assets/52a028b6-9c49-44e2-9214-7a99227786bd" /> |

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 悪習慣一覧上でブックマークボタンが右上に表示されているか
- [ ] 悪習慣詳細画面でブックマークボタンが右上に表示されているか

## 補足・備考・後でやること
なし