### PR TITLE
refactor: AntiHabitモデルに3つのscopeを追加(recent, with_tags, with_associations)

### DIFF
--- a/app/controllers/anti_habits_controller.rb
+++ b/app/controllers/anti_habits_controller.rb
@@ -6,8 +6,8 @@ class AntiHabitsController < ApplicationController
 
     @anti_habits = @q.result
       .publicly_visible
-      .includes(:user, :tags, :reactions, :comments)
-      .order(created_at: :desc)
+      .with_associations
+      .recent
       .page(params[:page])
 
     @all_tags = Tag.order(:name)
@@ -20,7 +20,7 @@ class AntiHabitsController < ApplicationController
       AntiHabit.ransack(title_cont: query).result
         .publicly_visible
         .limit(10)
-        .order(created_at: :desc)
+        .recent
     else
       AntiHabit.none
     end
@@ -41,7 +41,7 @@ class AntiHabitsController < ApplicationController
   end
 
   def show
-    @anti_habit = AntiHabit.includes(:tags).find(params[:id])
+    @anti_habit = AntiHabit.with_tags.find(params[:id])
 
     unless @anti_habit.is_public || current_user&.own?(@anti_habit)
       redirect_to anti_habits_path, alert: "このページにアクセスする権限がありません。"
@@ -72,7 +72,7 @@ class AntiHabitsController < ApplicationController
   end
 
   def edit
-    @anti_habit = current_user.anti_habits.includes(:tags).find(params[:id])
+    @anti_habit = current_user.anti_habits.with_tags.find(params[:id])
     @anti_habit.tag_names = @anti_habit.tag_names_as_string
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,8 +4,8 @@ class BookmarksController < ApplicationController
   def index
     @bookmarked_anti_habits = current_user
       .bookmarked_anti_habits
-      .where(is_public: true)
-      .includes(:user, :tags, :reactions, :comments)
+      .publicly_visible
+      .with_associations
       .order("bookmarks.created_at DESC")
       .page(params[:page])
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
   private
 
   def set_anti_habit
-    @anti_habit = AntiHabit.includes(:tags).find(params[:anti_habit_id])
+    @anti_habit = AntiHabit.with_tags.find(params[:anti_habit_id])
   end
 
   def comment_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,6 @@ class UsersController < ApplicationController
     end
 
     @user = current_user
-    @anti_habits = current_user.anti_habits.includes(:tags, :reactions, :comments).order(created_at: :desc)
+    @anti_habits = current_user.anti_habits.includes(:tags, :reactions, :comments).recent
   end
 end

--- a/app/models/anti_habit.rb
+++ b/app/models/anti_habit.rb
@@ -23,6 +23,9 @@ class AntiHabit < ApplicationRecord
     joins(:tags).where(tags: { name: name })
   }
   scope :publicly_visible, -> { where(is_public: true) }
+  scope :recent, -> { order(created_at: :desc) }
+  scope :with_tags, -> { includes(:tags) }
+  scope :with_associations, -> { includes(:user, :tags, :reactions, :comments) }
 
   attr_accessor :tag_names
 


### PR DESCRIPTION
# issue
close: #212 

# 実装概要
AntiHabitモデルに3つのscopeを追加(recent, with_tags, with_associations)

## recent
`order(created_at: :desc)`

## with_tags
`includes(:tags)`

## with_associations
`includes(:user, :tags, :reactions, :comments)`

## 追加実装
なし

## 動作確認チェックリスト
- [ ] 使用箇所で動作が変わっていないこと

## 補足・備考・後でやること
なし