### PR TITLE
fix: Solid QueueのスレッドをRAILS_MAX_THREADSに合わせて変更

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: <%= ENV.fetch("RAILS_MAX_THREADS", 2) %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 


### PR DESCRIPTION
## 概要

- `config/queue.yml` の `threads: 3` を `RAILS_MAX_THREADS` 環境変数を参照するよう変更

## 変更内容

```yaml
# before
threads: 3

# after
threads: <%= ENV.fetch("RAILS_MAX_THREADS", 2) %>
```

## 背景

メモリ使用量削減のため `RAILS_MAX_THREADS=2` に変更したが、Solid Queue のスレッド数が固定値 `3` のままだったため、データベース接続プールとの不整合が生じる可能性があった。

Close #251