### PR TITLE
fix: 本番DBの接続設定をDATABASE_URLを使用する方法に変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ test:
   database: myapp_test
 
 production:
-  <<: *default
-  database: myapp_production
-  username: myapp
-  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
## 概要

本番環境のデータベース設定を `DATABASE_URL` を使用する方式に変更。

## 変更内容

- `database`, `username`, `password` の個別指定を削除
- `url: <%= ENV["DATABASE_URL"] %>` を使用する形式に統一

## 関連issue

Close #253